### PR TITLE
chore: Normalize repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ MIT
 [npm-url]: https://www.npmjs.com/package/undertaker-common-tasks
 [npm-image]: https://img.shields.io/npm/v/undertaker-common-tasks.svg?style=flat-square
 [ci-url]: https://github.com/gulpjs/undertaker-common-tasks/actions?query=workflow:dev
-[ci-image]: https://img.shields.io/github/workflow/status/gulpjs/undertaker-common-tasks/dev?style=flat-square
+[ci-image]: https://img.shields.io/github/actions/workflow/status/gulpjs/undertaker-common-tasks/dev.yml?branch=master&style=flat-square
 [coveralls-url]: https://coveralls.io/r/gulpjs/undertaker-common-tasks
 [coveralls-image]: https://img.shields.io/coveralls/gulpjs/undertaker-common-tasks.svg?style=flat-square
 


### PR DESCRIPTION
The URL of GitHub workflow badge was changed by badges/shields's issue `#8671`.
This PR modifies the URL in `README.md`.